### PR TITLE
missing semicolon as reported by jshint

### DIFF
--- a/url.js
+++ b/url.js
@@ -139,7 +139,7 @@
 							if (len) {
 								for (var ii = 0; ii < len; ii++) {
 									s += s ? '&' : '';
-									s += e( i) + '=' + e( this[i][ii])
+									s += e( i) + '=' + e( this[i][ii]);
 								}
 							}
 	


### PR DESCRIPTION
Hi,
Cool project I've been looking for something like this for a while.

I noticed my editor reported a missing semi colon in the minified file, not being sure whether it was just the editor getting confused because of the minification I passed it through jshint.com

It reported a missing semi colon for line 142

s += e( i) + '=' + e( this[i][ii])

There's a few tricks I haven't seen before (cool use of aliasing encodeURIComponent), so perhaps the missing semi colon is an intentional trick, but just in case it's not.

-thanks
Alex.
