### PR TITLE
Loosely compare ports in IE & Android fix since they can be strings

### DIFF
--- a/url.js
+++ b/url.js
@@ -70,7 +70,8 @@
         self.user = decode(auth[1] || '');
         self.pass = decode(auth[2] || '');
         self.port = (
-            defaultPorts[self.protocol] === self.port || self.port === 0
+            // loosely compare because port can be a string
+            defaultPorts[self.protocol] == self.port || self.port == 0
         ) ? '' : self.port; // IE fix, Android browser fix
 
         if (!self.protocol && !/^([a-z]+:)?\/\/\/?/.test(url)) {


### PR DESCRIPTION
Since the port can be a string (or maybe it always is), we can't strictly compare it to the integers in our `defaultPorts` map. 

I saw that it used to be like this in a previous version (from Dec 4 2015) https://github.com/Mikhus/domurl/blob/479f499f61607071aa137931793e102246554daa/url.js#L60, so it looks like the comparisons were made strict by mistake? I added a comment anyhow to make this clear. 